### PR TITLE
Sync panel RTC via SERVICE 0x0023 broadcasts

### DIFF
--- a/src/econext_gateway/api/routes.py
+++ b/src/econext_gateway/api/routes.py
@@ -8,6 +8,8 @@ from econext_gateway.api.dependencies import get_cache, get_handler, get_virtual
 from econext_gateway.core.cache import ParameterCache
 from econext_gateway.core.models import (
     AlarmsResponse,
+    ClockSyncRequest,
+    ClockSyncResponse,
     ErrorResponse,
     ParameterSetRequest,
     ParameterSetResponse,
@@ -91,6 +93,28 @@ async def set_parameter(
         old_value=old_value,
         new_value=request.value,
     )
+
+
+@router.post(
+    "/clock/sync",
+    response_model=ClockSyncResponse,
+    responses={503: {"model": ErrorResponse}},
+)
+async def sync_clock(
+    request: ClockSyncRequest,
+    handler: ProtocolHandler = Depends(get_handler),
+):
+    """Broadcast a SERVICE 0x0023 clock-sync frame on the bus.
+
+    Test endpoint: lets us probe whether the panel accepts an external
+    time source. Pass `when` to broadcast a deliberately-wrong time;
+    omit it to broadcast host current time.
+    """
+    if not handler.connected:
+        raise HTTPException(status_code=503, detail="Controller not connected")
+    target = request.when or datetime.now()
+    await handler.broadcast_clock_sync(target)
+    return ClockSyncResponse(success=True, broadcast=target)
 
 
 @router.get("/alarms", response_model=AlarmsResponse)

--- a/src/econext_gateway/core/config.py
+++ b/src/econext_gateway/core/config.py
@@ -31,6 +31,15 @@ class Settings(BaseSettings):
     thermostat_max_age: float = 300.0
     thermostat_stale_fallback: float = 19.0
 
+    # Panel RTC sync. Gateway broadcasts SERVICE 0x0023 to keep the panel
+    # (and via its rebroadcast cycle, the controller) on host-clock time.
+    # Daily anchor at clock_sync_hour:clock_sync_minute local; an additional
+    # sync is triggered whenever a wall/monotonic skew is detected (DST or
+    # NTP step).
+    clock_sync_enabled: bool = True
+    clock_sync_hour: int = 3
+    clock_sync_minute: int = 30
+
     model_config = SettingsConfigDict(env_prefix="ECONEXT_")
 
     @property

--- a/src/econext_gateway/core/models.py
+++ b/src/econext_gateway/core/models.py
@@ -189,6 +189,22 @@ class ErrorResponse(BaseModel):
     )
 
 
+class ClockSyncRequest(BaseModel):
+    """Request model for POST /api/clock/sync."""
+
+    when: datetime | None = Field(
+        None,
+        description="Datetime to broadcast. Defaults to host current time.",
+    )
+
+
+class ClockSyncResponse(BaseModel):
+    """Response model for POST /api/clock/sync."""
+
+    success: bool = Field(True, description="Operation success status")
+    broadcast: datetime = Field(..., description="Datetime that was broadcast")
+
+
 class ThermostatSubmitRequest(BaseModel):
     """Request model for POST /api/thermostat/temperature."""
 

--- a/src/econext_gateway/main.py
+++ b/src/econext_gateway/main.py
@@ -88,6 +88,8 @@ async def lifespan(app: FastAPI):
         paired_address_file=settings.paired_address_file,
         thermostat_emulator=thermostat_emulator,
         thermostat_address_file=settings.thermostat_address_file if settings.thermostat_enabled else None,
+        clock_sync_hour=settings.clock_sync_hour if settings.clock_sync_enabled else None,
+        clock_sync_minute=settings.clock_sync_minute,
     )
 
     # Connect and start polling

--- a/src/econext_gateway/protocol/constants.py
+++ b/src/econext_gateway/protocol/constants.py
@@ -159,7 +159,12 @@ GET_TOKEN_FUNC = 0x0801  # Token grant function code
 DEVICE_TABLE_FUNC = 0x2001  # Device table broadcast function code
 PAIRING_BEACON_FUNC = 0x2004  # Pairing mode beacon (panel broadcasts rapidly)
 PAIRING_ASSIGN_FUNC = 0x2005  # Address assignment (panel assigns address after SERVICE_ANS)
+CLOCK_SYNC_FUNC = 0x0023  # Clock/timer sync (panel broadcasts current RTC every ~10s)
 GIVE_BACK_TOKEN_DATA = b"\x00\x08\x00\x00"  # Token return payload
+
+# 8-byte header common to SERVICE frames after the func code (alarm read,
+# clock sync). Captured identically across all observed broadcasts.
+SERVICE_FIXED_HEADER = b"\x00\x00\x01\x01\x00\x01\x01\x00"
 TOKEN_TIMEOUT = 5.0  # Max time to wait for token grant (seconds, ~0.5 panel cycle)
 
 # Alarm reading

--- a/src/econext_gateway/protocol/handler.py
+++ b/src/econext_gateway/protocol/handler.py
@@ -26,6 +26,7 @@ from econext_gateway.protocol.codec import decode_value, encode_value
 from econext_gateway.protocol.constants import (
     ALARM_REQUEST_PREFIX,
     CLAIMABLE_ADDRESS_RANGE,
+    CLOCK_SYNC_FUNC,
     CONTROLLER_ADDRESS,
     DEVICE_TABLE_FUNC,
     GET_TOKEN_FUNC,
@@ -37,6 +38,7 @@ from econext_gateway.protocol.constants import (
     POLL_INTERVAL,
     REQUEST_TIMEOUT,
     RETRY_ATTEMPTS,
+    SERVICE_FIXED_HEADER,
     THERMOSTAT_CLAIMABLE_ADDRESS_RANGE,
     TOKEN_TIMEOUT,
     TYPE_SIZES,
@@ -576,6 +578,8 @@ class ProtocolHandler:
         paired_address_file: Path | None = None,
         thermostat_emulator: ThermostatEmulator | None = None,
         thermostat_address_file: Path | None = None,
+        clock_sync_hour: int | None = 3,
+        clock_sync_minute: int = 30,
     ):
         """Initialize protocol handler.
 
@@ -599,6 +603,9 @@ class ProtocolHandler:
             thermostat_address_file: Path to persist thermostat bus address.
                 When the thermostat has address=0 it will auto-register
                 via IDENTIFY during pairing and persist the address here.
+            clock_sync_hour: Hour of day (local time) for the daily panel
+                RTC sync broadcast. Set to None to disable.
+            clock_sync_minute: Minute of the hour for the daily sync.
         """
         self._connection = connection
         self._cache = cache
@@ -635,6 +642,9 @@ class ProtocolHandler:
                 source="self",
             )
         self._poll_task: asyncio.Task | None = None
+        self._clock_sync_task: asyncio.Task | None = None
+        self._clock_sync_hour = clock_sync_hour
+        self._clock_sync_minute = clock_sync_minute
         self._running = False
         self._lock = asyncio.Lock()
         self._lock_holder: str | None = None
@@ -954,6 +964,10 @@ class ProtocolHandler:
             self._bus_silence_watchdog(), name="BusSilenceWatchdog"
         )
         self._poll_task = asyncio.create_task(self._poll_loop())
+        if self._clock_sync_hour is not None:
+            self._clock_sync_task = asyncio.create_task(
+                self._clock_sync_loop(), name="ClockSyncLoop"
+            )
         logger.info("Protocol handler started")
 
     async def stop(self) -> None:
@@ -975,6 +989,14 @@ class ProtocolHandler:
             except asyncio.CancelledError:
                 pass
             self._watchdog_task = None
+
+        if self._clock_sync_task is not None:
+            self._clock_sync_task.cancel()
+            try:
+                await self._clock_sync_task
+            except asyncio.CancelledError:
+                pass
+            self._clock_sync_task = None
 
         if self._dispatcher is not None:
             await self._dispatcher.stop()
@@ -1850,6 +1872,144 @@ class ProtocolHandler:
         self._alarms = alarms
         logger.info("Read %d alarms from controller", len(alarms))
         return alarms
+
+    @staticmethod
+    def _build_clock_sync_payload(when: datetime) -> bytes:
+        """Build the 20-byte SERVICE 0x0023 payload for *when*.
+
+        Layout (matches captured panel broadcasts byte-for-byte):
+        [0:2]  func code 0x0023 (LE16)
+        [2:10] fixed 8-byte header
+        [10]   second
+        [11]   minute
+        [12]   hour
+        [13]   day-of-month
+        [14]   month (1-12)
+        [15:17] year (LE16)
+        [17]   day-of-week (1=Mon..7=Sun)
+        [18:20] tail constants 0x01 0x00
+        """
+        return (
+            struct.pack("<H", CLOCK_SYNC_FUNC)
+            + SERVICE_FIXED_HEADER
+            + bytes([when.second, when.minute, when.hour, when.day, when.month])
+            + struct.pack("<H", when.year)
+            + bytes([when.isoweekday(), 0x01, 0x00])
+        )
+
+    async def broadcast_clock_sync(self, when: datetime) -> None:
+        """Broadcast SERVICE 0x0023 (clock sync) to all bus devices.
+
+        The master panel adopts our broadcast as its own RTC and propagates
+        it to the controller via the regular ~10s rebroadcast cycle. This
+        is the only mechanism that actually sets the panel's clock —
+        MODIFY_PARAM writes to the RTC fields are silently ignored.
+        """
+        if not self.connected:
+            raise RuntimeError("Cannot broadcast clock sync: bus not connected")
+
+        payload = self._build_clock_sync_payload(when)
+        frame = Frame(
+            destination=0xFFFF,
+            command=Command.SERVICE,
+            data=payload,
+            source=self._source_address,
+        )
+        async with self._traced_lock("api:broadcast_clock_sync"):
+            await self._wait_for_token()
+            try:
+                # Bus turnaround delay before transmitting (matches _return_token)
+                await asyncio.sleep(0.02)
+                await self._connection.protocol.write_frame(frame)
+            finally:
+                if self._has_token:
+                    await self._return_token()
+        logger.info(
+            "Broadcast clock sync: %s (payload=%s)",
+            when.isoformat(timespec="seconds"),
+            payload.hex(),
+        )
+
+    # Tunable parameters for the clock sync background task. Exposed at
+    # class level so tests can override them without monkey-patching globals.
+    _CLOCK_SYNC_STARTUP_DELAY_S = 60.0
+    _CLOCK_SYNC_CHECK_INTERVAL_S = 600.0
+    _CLOCK_SYNC_SKEW_THRESHOLD_S = 90.0
+    _CLOCK_SYNC_REQUEST_TIMEOUT_S = 30.0
+
+    async def _do_clock_sync(self, reason: str) -> bool:
+        """Run a single clock-sync broadcast, swallowing failures.
+
+        Returns True if the broadcast was sent, False otherwise. The task
+        loop uses the return to decide whether to update its "last synced"
+        bookkeeping.
+        """
+        try:
+            when = datetime.now()
+            await asyncio.wait_for(
+                self.broadcast_clock_sync(when),
+                timeout=self._CLOCK_SYNC_REQUEST_TIMEOUT_S,
+            )
+            logger.info(
+                "Clock sync (%s): broadcast %s",
+                reason,
+                when.isoformat(timespec="seconds"),
+            )
+            return True
+        except Exception:
+            logger.exception("Clock sync broadcast failed (%s)", reason)
+            return False
+
+    async def _clock_sync_loop(self) -> None:
+        """Keep the panel's RTC aligned with the host clock.
+
+        Runs one broadcast at startup (after the bus has settled), one
+        per day at the configured local hour:minute, and an extra one
+        whenever a wall vs monotonic skew larger than the threshold is
+        detected -- this catches DST transitions and NTP step corrections
+        that happen between daily anchors.
+        """
+        # Let the bus initialise (token grants, address registration)
+        # before transmitting. Cancellation during this window is a
+        # normal stop, not an error.
+        try:
+            await asyncio.sleep(self._CLOCK_SYNC_STARTUP_DELAY_S)
+        except asyncio.CancelledError:
+            return
+
+        await self._do_clock_sync("startup")
+        last_synced_date = datetime.now().date()
+        last_check_mono = _time.monotonic()
+        last_check_wall = datetime.now()
+
+        while self._running:
+            try:
+                await asyncio.sleep(self._CLOCK_SYNC_CHECK_INTERVAL_S)
+            except asyncio.CancelledError:
+                return
+            if not self._running:
+                return
+
+            now_wall = datetime.now()
+            now_mono = _time.monotonic()
+            wall_elapsed = (now_wall - last_check_wall).total_seconds()
+            mono_elapsed = now_mono - last_check_mono
+            skew = abs(wall_elapsed - mono_elapsed)
+            last_check_wall = now_wall
+            last_check_mono = now_mono
+
+            if skew > self._CLOCK_SYNC_SKEW_THRESHOLD_S:
+                if await self._do_clock_sync(f"clock-skew={skew:.0f}s"):
+                    last_synced_date = now_wall.date()
+                continue
+
+            anchor_passed = (now_wall.hour, now_wall.minute) >= (
+                self._clock_sync_hour,
+                self._clock_sync_minute,
+            )
+            if anchor_passed and last_synced_date != now_wall.date():
+                if await self._do_clock_sync("daily"):
+                    last_synced_date = now_wall.date()
 
     async def _discover_address_space(
         self,

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1882,6 +1882,241 @@ class TestReadAlarms:
         assert len(handler._alarms) == 1  # original unchanged
 
 
+class TestClockSyncBroadcast:
+    """Tests for the SERVICE 0x0023 clock-sync broadcast."""
+
+    @pytest.fixture
+    def handler(self, paired_address_file):
+        conn = MagicMock(spec=GM3SerialTransport)
+        conn.connected = True
+        conn.protocol = MagicMock()
+        conn.protocol.write_frame = AsyncMock(return_value=True)
+        cache = ParameterCache()
+        h = ProtocolHandler(
+            conn,
+            cache,
+            token_required=False,
+            token_timeout=0,
+            paired_address_file=paired_address_file,
+        )
+        return h
+
+    def test_payload_matches_captured_panel_broadcast(self):
+        """Built payload must match a real panel broadcast byte-for-byte."""
+        # Capture from logs: Mar 18 17:46, panel at 17:49:19 Wednesday
+        from datetime import datetime as _dt
+
+        when = _dt(2026, 3, 18, 17, 49, 19)
+        payload = ProtocolHandler._build_clock_sync_payload(when)
+        assert payload.hex() == "230000000101000101001331111203ea07030100"
+
+    def test_payload_layout_for_each_field(self):
+        """Each datetime field must land in the documented byte position."""
+        from datetime import datetime as _dt
+
+        # Sun 2026-12-27 23:59:58 -> isoweekday=7 (Sunday)
+        when = _dt(2026, 12, 27, 23, 59, 58)
+        payload = ProtocolHandler._build_clock_sync_payload(when)
+
+        assert len(payload) == 20
+        assert payload[0:2] == b"\x23\x00"  # func code 0x0023 LE
+        assert payload[10] == 58  # second
+        assert payload[11] == 59  # minute
+        assert payload[12] == 23  # hour
+        assert payload[13] == 27  # day-of-month
+        assert payload[14] == 12  # month
+        assert struct.unpack("<H", payload[15:17])[0] == 2026
+        assert payload[17] == 7  # Sunday in ISO weekday
+        assert payload[18:20] == b"\x01\x00"
+
+    @pytest.mark.asyncio
+    async def test_broadcast_sends_correct_frame(self, handler):
+        """broadcast_clock_sync writes a SERVICE frame to dest=0xFFFF."""
+        from datetime import datetime as _dt
+
+        await handler.broadcast_clock_sync(_dt(2026, 5, 7, 14, 30, 0))
+
+        handler._connection.protocol.write_frame.assert_awaited_once()
+        sent = handler._connection.protocol.write_frame.await_args.args[0]
+        assert isinstance(sent, Frame)
+        assert sent.destination == 0xFFFF
+        assert sent.command == Command.SERVICE
+        assert sent.data[0:2] == b"\x23\x00"
+        assert len(sent.data) == 20
+
+    @pytest.mark.asyncio
+    async def test_broadcast_refuses_when_disconnected(self, handler):
+        """No frame is sent when the bus is down."""
+        from datetime import datetime as _dt
+
+        handler._connection.connected = False
+
+        with pytest.raises(RuntimeError, match="not connected"):
+            await handler.broadcast_clock_sync(_dt(2026, 5, 7, 14, 30, 0))
+
+        handler._connection.protocol.write_frame.assert_not_called()
+
+
+class TestClockSyncLoop:
+    """Tests for the daily / DST-aware clock-sync background task."""
+
+    @pytest.fixture
+    def handler(self, paired_address_file):
+        conn = MagicMock(spec=GM3SerialTransport)
+        conn.connected = True
+        conn.protocol = MagicMock()
+        conn.protocol.write_frame = AsyncMock(return_value=True)
+        cache = ParameterCache()
+        h = ProtocolHandler(
+            conn,
+            cache,
+            token_required=False,
+            token_timeout=0,
+            paired_address_file=paired_address_file,
+            clock_sync_hour=3,
+            clock_sync_minute=30,
+        )
+        # Tight loop timings so the test runs fast.
+        h._CLOCK_SYNC_STARTUP_DELAY_S = 0.0
+        h._CLOCK_SYNC_CHECK_INTERVAL_S = 0.01
+        h._CLOCK_SYNC_REQUEST_TIMEOUT_S = 1.0
+        h._running = True
+        return h
+
+    @pytest.fixture
+    def handler_no_skew_check(self, handler):
+        """Handler with skew detection effectively disabled."""
+        handler._CLOCK_SYNC_SKEW_THRESHOLD_S = 1e9
+        return handler
+
+    @pytest.mark.asyncio
+    async def test_initial_sync_then_daily_anchor(self, handler_no_skew_check, monkeypatch):
+        handler = handler_no_skew_check
+        """Loop fires once at startup; second iteration only fires after the
+        daily anchor crosses on a fresh date."""
+        from datetime import datetime as _dt
+
+        calls: list[tuple[str, _dt]] = []
+
+        async def fake_sync(reason: str) -> bool:
+            calls.append((reason, _dt(*fake_now_state)))
+            return True
+
+        # Sequence of "now" values driven by pop-from-front
+        now_sequence = [
+            (2026, 5, 7, 4, 0, 0),  # startup -> sync
+            (2026, 5, 7, 4, 0, 1),  # last_synced_date set
+            (2026, 5, 7, 5, 0, 0),  # same day, anchor passed -> no resync
+            (2026, 5, 7, 5, 0, 1),
+            (2026, 5, 8, 3, 30, 5),  # next day, anchor crossed -> sync
+            (2026, 5, 8, 3, 30, 6),
+        ]
+        fake_now_state = now_sequence[0]
+
+        def fake_datetime_now():
+            nonlocal fake_now_state
+            fake_now_state = now_sequence.pop(0) if now_sequence else fake_now_state
+            return _dt(*fake_now_state)
+
+        monkeypatch.setattr(
+            "econext_gateway.protocol.handler.datetime", _FrozenDT(fake_datetime_now)
+        )
+        handler._do_clock_sync = fake_sync
+
+        # Run the loop until the sequence is exhausted
+        task = asyncio.create_task(handler._clock_sync_loop())
+        for _ in range(20):
+            await asyncio.sleep(0.02)
+            if not now_sequence:
+                break
+        handler._running = False
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        reasons = [r for r, _ in calls]
+        assert "startup" in reasons
+        assert "daily" in reasons
+
+    @pytest.mark.asyncio
+    async def test_skew_triggers_sync(self, handler, monkeypatch):
+        """A wall-vs-monotonic skew larger than the threshold forces a sync."""
+        from datetime import datetime as _dt
+
+        calls: list[str] = []
+
+        async def fake_sync(reason: str) -> bool:
+            calls.append(reason)
+            return True
+
+        # Wall clock jumps by 1h between iterations while monotonic only ticks
+        # the configured check interval -> skew ~3600s, well above threshold.
+        wall_seq = [
+            _dt(2026, 5, 7, 4, 0, 0),  # startup
+            _dt(2026, 5, 7, 4, 0, 1),  # baseline after startup sync
+            _dt(2026, 5, 7, 5, 0, 5),  # +1h wall jump -> skew detected
+            _dt(2026, 5, 7, 5, 0, 6),
+        ]
+
+        def fake_now():
+            return wall_seq.pop(0) if wall_seq else wall_seq[-1] if wall_seq else _dt(2026, 5, 7, 5, 0, 6)
+
+        monkeypatch.setattr(
+            "econext_gateway.protocol.handler.datetime", _FrozenDT(fake_now)
+        )
+        handler._do_clock_sync = fake_sync
+
+        task = asyncio.create_task(handler._clock_sync_loop())
+        for _ in range(30):
+            await asyncio.sleep(0.02)
+            if not wall_seq:
+                break
+        handler._running = False
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert any("skew" in r for r in calls), f"expected a skew sync in {calls}"
+
+    @pytest.mark.asyncio
+    async def test_loop_not_started_when_hour_is_none(self, paired_address_file):
+        """Setting clock_sync_hour=None disables the task entirely."""
+        conn = MagicMock(spec=GM3SerialTransport)
+        conn.connected = True
+        cache = ParameterCache()
+        h = ProtocolHandler(
+            conn,
+            cache,
+            token_required=False,
+            token_timeout=0,
+            paired_address_file=paired_address_file,
+            clock_sync_hour=None,
+        )
+        assert h._clock_sync_hour is None
+        # start() must not create the task; we don't actually call start()
+        # here because it spins up the dispatcher and serial machinery, but
+        # the explicit None check guards against accidental enablement.
+
+
+class _FrozenDT:
+    """datetime stand-in whose .now() returns a caller-provided value.
+
+    Used in tests above to drive the clock-sync loop without real time.
+    """
+
+    def __init__(self, now_fn):
+        self._now_fn = now_fn
+
+    def now(self):
+        return self._now_fn()
+
+
 class TestParseDeviceTable:
     """Tests for parse_device_table (SERVICE 0x2001)."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -65,7 +65,7 @@ wheels = [
 
 [[package]]
 name = "econext-gateway"
-version = "0.2.0a5"
+version = "0.2.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
The master panel is the bus's authoritative timekeeper -- it broadcasts SERVICE 0x0023 every ~10s, and the controller (and any other slaves) adopt that as their RTC. The panel's RTC drifts several minutes per day and is unaware of DST transitions on the host network.

MODIFY_PARAM writes against the RTC fields (year/months/.../RTCSet) get ACKed but are silently discarded; the panel keeps running its own clock. The 0x0023 broadcast is the only mechanism that actually sets the panel.

Add a 20-byte payload builder matching the captured panel format byte-for-byte, a `broadcast_clock_sync` method that grabs the bus token and emits the broadcast as the gateway, and a background task that runs one sync at startup, then daily at 03:30 local, plus an extra sync any time a wall-vs-monotonic skew >90s is detected (DST step or NTP jump).

Also expose POST /api/clock/sync for ad-hoc syncs and forced bad-time testing.