### PR TITLE
Fix writes to panel parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /app
 
 # Copy project files
-COPY pyproject.toml ./
+COPY pyproject.toml README.md ./
 COPY src/ ./src/
 
 # Install dependencies

--- a/src/econext_gateway/protocol/handler.py
+++ b/src/econext_gateway/protocol/handler.py
@@ -1885,7 +1885,14 @@ class ProtocolHandler:
         if max_val is not None and float(value) > max_val:
             raise ValueError(f"Value {value} above maximum {max_val} for {name}")
 
-        data = build_modify_param_request(param.index, value, entry.type_code)
+        # Panel parameters are stored with a 10000 offset so they cannot
+        # collide with regulator parameters in the shared cache.  The offset
+        # is local to the gateway: on the wire the panel expects its original
+        # index and the request must be addressed to the panel itself.
+        is_panel = param.index >= 10000
+        wire_index = param.index - 10000 if is_panel else param.index
+        destination = PANEL_ADDRESS if is_panel else None
+        data = build_modify_param_request(wire_index, value, entry.type_code)
 
         async with self._traced_lock(f"api:write_param:{name}"):
             try:
@@ -1895,6 +1902,7 @@ class ProtocolHandler:
                     Command.MODIFY_PARAM,
                     data,
                     expected_response=Command.MODIFY_PARAM_RESPONSE,
+                    destination=destination,
                 )
             finally:
                 if self._has_token:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -698,6 +698,49 @@ class TestProtocolHandler:
         assert cached.value == 65
 
     @pytest.mark.asyncio
+    async def test_write_panel_param_uses_wire_index_and_panel_destination(self):
+        """Panel cache offsets must not be sent as physical parameter indices."""
+        handler, conn, cache = self._make_handler()
+
+        handler._param_structs = {
+            10023: ParamStructEntry(
+                index=10023,
+                name="currentWebPage",
+                unit=0,
+                type_code=DataType.UINT16,
+                writable=True,
+            ),
+        }
+        await cache.set(
+            Parameter(
+                index=10023,
+                name="currentWebPage",
+                value=729,
+                type=DataType.UINT16,
+                unit=0,
+                writable=True,
+            )
+        )
+
+        handler._wait_for_token = AsyncMock()
+        handler.send_and_receive = AsyncMock(
+            return_value=self._response_frame(Command.MODIFY_PARAM_RESPONSE)
+        )
+
+        result = await handler.write_param("currentWebPage", 696)
+
+        assert result is True
+        handler.send_and_receive.assert_awaited_once_with(
+            Command.MODIFY_PARAM,
+            build_modify_param_request(23, 696, DataType.UINT16),
+            expected_response=Command.MODIFY_PARAM_RESPONSE,
+            destination=PANEL_ADDRESS,
+        )
+        cached = await cache.get(10023)
+        assert cached is not None
+        assert cached.value == 696
+
+    @pytest.mark.asyncio
     async def test_write_param_not_found(self):
         """Test writing nonexistent parameter raises error."""
         handler, conn, cache = self._make_handler()


### PR DESCRIPTION
﻿## What changed

- route writes for cached panel parameters (`10000+`) to panel address 100
- remove the local 10000 cache offset before encoding the wire request
- preserve existing regulator parameter write behavior
- add a regression test for `currentWebPage` (`10023` -> wire index `23`)

## Why

Panel reads already translated the cache offset and used the panel destination, but `write_param()` sent the stored index directly to the regulator. The controller therefore did not acknowledge writes to panel parameters.

## Validation

- `uv run pytest tests/test_handler.py -x -q`: 95 passed
- `uv run pytest tests -q`: 325 passed
- physical ecoMAX 360i test: `currentWebPage` write acknowledged and reflected by the panel
