### PR TITLE
Change license to PolyForm Noncommercial 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ logs/
 # Temporary files
 *.tmp
 *.bak
+
+# Claude Code project files
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ First stable release since 0.1.0-beta.2. Everything below shipped through the
 
 ### Changed
 
+- License changed from MIT to PolyForm Noncommercial 1.0.0: free for
+  private, non-profit, educational and government use; commercial use requires
+  a paid license. Earlier releases remain MIT.
 - Frame dispatching moved off the handler lock, so Home Assistant writes are no
   longer starved by bus traffic.
 - Steady-state logging is much quieter at INFO.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,133 @@
+Required Notice: Copyright 2026 Linus Reitmayr (https://github.com/LeeNuss/econext-gateway)
+
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/README.md
+++ b/README.md
@@ -391,4 +391,11 @@ uv run uvicorn econext_gateway.main:app --host 0.0.0.0 --port 8000
 
 ## License
 
-MIT
+Copyright 2026 Linus Reitmayr. Licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE).
+
+- **Free** for personal / private use, and for non-profit, educational, research and government use. You may use, modify and redistribute the gateway for those purposes.
+- **Commercial use requires a paid license.** This includes use by heating installers, heat pump manufacturers or distributors, energy service providers, or bundling the gateway into a product or service. Contact the author via GitHub ([LeeNuss](https://github.com/LeeNuss)) to arrange one.
+
+Versions released before this change (up to v0.2.0b4) remain available under their original MIT license.
+
+By contributing to this repository you agree that your contribution is licensed under the same terms and that the copyright holder may also license it commercially.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ version = "0.2.0"
 description = "Local REST API gateway for heat pump controllers using GM3 protocol"
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = { text = "PolyForm-Noncommercial-1.0.0" }
+license-files = ["LICENSE"]
 authors = [
     { name = "Linus" }
 ]


### PR DESCRIPTION
Switches the project license from MIT to [PolyForm Noncommercial 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0/) ahead of the v0.2.0 stable release.

- Personal / private use and use by non-profits, educational, research and government organisations stay free (use, modify, redistribute).
- Commercial use (installers, manufacturers, distributors, service providers, bundling into products) requires a separate paid license.
- `LICENSE` contains the full text with a `Required Notice` line; `pyproject.toml` sets `license` / `license-files` so the wheel ships it (`License: PolyForm-Noncommercial-1.0.0`, `License-File: LICENSE` verified in the built METADATA).
- README license section explains the terms and how to obtain a commercial license; CHANGELOG entry under 0.2.0.
- Releases up to v0.2.0b4 remain MIT.

All runtime dependencies are permissive (MIT / BSD / Apache-2.0 / PSF / MPL-2.0, none vendored), so nothing constrains this change. The gateway has no outside contributors, so no re-consent is needed.